### PR TITLE
repare designated area for js working

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -35,7 +35,9 @@ $(window).on('load',function(){
 
           
           var reloadMessages = function() {
-            document.addEventListener('touchmove', function(e) {e.preventDefault();}, {passive: false});
+            if(document.URL.match(/(messages)/)) {
+            
+        
             
             var list = [0];
           $(".lower-message").each(function() {
@@ -75,7 +77,7 @@ $(window).on('load',function(){
           .fail(function() {
             console.log('error');
           })
-      
+        }
       };
       setInterval(reloadMessages, 5000);
       


### PR DESCRIPTION
#what  特定エリアでだけjsが動くように再設定
#why 自動更新機能で最初にmessageエリアでonになってしまうと他のページに移動してもon
しっぱなしのため他のurlでエラーがで続けた
自動更新の所に再度urlエリアフィルターを設置